### PR TITLE
Fix trossen_ai dependency resolution: pin lerobot_trossen to a commit and bump trossen-arm to 1.10.0

### DIFF
--- a/examples/trossen_ai/README.md
+++ b/examples/trossen_ai/README.md
@@ -190,11 +190,12 @@ The client will connect to the policy server and perform the specified task usin
 You can change the cameras and arm ip address in the script `examples/trossen_ai/main.py` by editing
 
 ```python
-bi_widowx_ai_config = BiWidowXAIFollowerConfig(
+robot_config = BiWidowXAIFollowerRobotConfig(
+            id="bimanual_follower",
             left_arm_ip_address="192.168.1.5",
             right_arm_ip_address="192.168.1.4",
             min_time_to_move_multiplier=4.0,
-            id="bimanual_follower",
+            loop_rate=30,
             cameras={
                 "cam_high": RealSenseCameraConfig(
                     serial_number_or_name="218622270304",

--- a/examples/trossen_ai/main.py
+++ b/examples/trossen_ai/main.py
@@ -95,7 +95,7 @@ class TrossenOpenPIBridge:
             self.max_steps + self.action_chunk_size
         )  # Buffer size to hold actions for the entire episode
 
-        self.action_dim = len(self.robot._joint_ft)  # 7 joints per arm * 2 arms
+        self.action_dim = len(self.robot.action_features)  # action_features = 7 dims per arm (6 joints + gripper) * 2 arms = 14
 
     def execute_action(self, action: np.ndarray):
         """Execute action on the arm."""
@@ -105,7 +105,7 @@ class TrossenOpenPIBridge:
             logger.info(f"TEST MODE: Would execute action: {full_action}")
             return
         if self.test_mode == "autonomous":
-            joint_features = list(self.robot._joint_ft.keys())
+            joint_features = list(self.robot.action_features.keys())
             action_dict = {k: full_action[i] for i, k in enumerate(joint_features)}
             self.robot.send_action(action_dict)
         else:

--- a/examples/trossen_ai/pyproject.toml
+++ b/examples/trossen_ai/pyproject.toml
@@ -23,7 +23,7 @@ allow-direct-references = true
 
 [tool.uv.sources]
 openpi-client = { path = "../../packages/openpi-client" }
-lerobot_trossen = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git", branch = "main" }
+lerobot_trossen = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git", rev = "810e60a3d973fa9b23b16db68613c0d4ee03b753" }
 dlimp = { git = "https://github.com/kvablack/dlimp", rev = "ad72ce3a9b414db2185bc0b38461d4101a65477a" }
 
 [tool.uv.workspace]

--- a/examples/trossen_ai/uv.lock
+++ b/examples/trossen_ai/uv.lock
@@ -2634,18 +2634,21 @@ wheels = [
 
 [[package]]
 name = "trossen-arm"
-version = "1.9.0"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/64/c327b6d8d1e9ff3131877ce16fa64d5d48570019745b4c874e42b2d09842/trossen_arm-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:845c0da526b397e5839684c8aafce048976a5eb9d2a699093adc3b64606c3af5", size = 779065, upload-time = "2025-09-10T21:57:02.848Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/3e/e0115b3518df5b0a65d515fab496b335f4c80db94f25b8e333c93d98f37c/trossen_arm-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a4d4a412b219b1770e2536b10ebf78bd49d0af351f5e7f37c43939a4584934f", size = 1114937, upload-time = "2025-09-10T21:57:04.389Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/15b9f1cf588a0d050f0b08c90a73aac4bd5028b9890f6716f159fa04c7a2/trossen_arm-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07c70a5efc085453e4c007f01b59c300ed72cc7a78c4459227b816190127a210", size = 1222221, upload-time = "2025-09-10T21:57:05.473Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/53/31154daca8c4d7481e8638c6c2984da4f483967f0de81c2c2b3977ed505c/trossen_arm-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f6ce500a48d29f372764718526771e857a92029658dc3bcd3b311683d49a44d9", size = 750207, upload-time = "2025-09-10T21:57:07.115Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/2e/913a9888e30f42ca197dcfce74eb611b36cf07d89591c1e35b96dd5f7dbd/trossen_arm-1.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9d0fbaadba04cb2dc6676667f45a9c9c27808f70c6ebaaa1a866132d00186cc", size = 1114970, upload-time = "2025-09-10T21:57:08.583Z" },
-    { url = "https://files.pythonhosted.org/packages/62/aa/4c4aee012dc10825eb41f6b5bea522cf67f86b34f39a40209f2333999de9/trossen_arm-1.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:685ad5e769ca0030b5adec48d12c3c4d3bf0590cd011aab9972b1ec8f3daeb9f", size = 1220924, upload-time = "2025-09-10T21:57:09.654Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/32/13307c7eef88cc656a00d41ea1925b749e7762fac6da7252ea7938c1b7d2/trossen_arm-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:76dbfae7841fad136e747be3921c2101801d25ac2f4ca176eec3027a9b1a5e74", size = 729263, upload-time = "2026-05-05T21:13:26.789Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a4/5e0f49b18d2533aee4536666d4b0117c9aeb5d3230f35b233e3c106a2b8a/trossen_arm-1.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e145bd36ffb53cdf1c6e6de4d4d2e8e5302ea599db0d716e75f97f61925631b7", size = 1026542, upload-time = "2026-05-05T21:13:28.287Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/bb/e0f2c80a1018f507b4dd252603d62196acdc558104cb3a7349c0cb35e72c/trossen_arm-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ebd6775ca42dc75ebd718ea080450b335daedc2eedbd6223cbdfe47dbe35cb1", size = 1134241, upload-time = "2026-05-05T21:13:29.604Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/35/4b9e702dbe5a844171e76d9e20e57f7d2ebce539dc25866a7dc665e24277/trossen_arm-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c7653ebeb8a0240ba0f6de99cfb63ef470d8d2cff13844f9a994e48d4c68095", size = 698112, upload-time = "2026-05-05T21:13:31.316Z" },
+    { url = "https://files.pythonhosted.org/packages/55/78/54758216c0b3fea040edabc452facf7e8363752e113e97e58bbc817b76f0/trossen_arm-1.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ecf68daf9c56829c6b8b0b8ea08b5d9ef8364424e847b32c321b31395d9fbb3", size = 1027422, upload-time = "2026-05-05T21:13:32.72Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e7/d6b208b9f48d4549ca39f992a6ef8ea9175fa675ed1ba9a61dcfc3cb6782/trossen_arm-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40c595fd535012f50e1e802cd23cde3daa4ad2c65a15907868cbe5b6969a3e51", size = 1137443, upload-time = "2026-05-05T21:13:34.122Z" },
+    { url = "https://files.pythonhosted.org/packages/10/37/11a89f928de15bc79e8151579b7aff1347842175cd02c9cf26c76a3a6bbb/trossen_arm-1.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d873626e07d2b734b4fa986911e19d7551379ce0b64167205abbbddb2d4de116", size = 698155, upload-time = "2026-05-05T21:13:35.287Z" },
+    { url = "https://files.pythonhosted.org/packages/68/39/ee18ee48aa32878da42244365dbdb91904dc082422a947686ee8d0953e40/trossen_arm-1.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:396a01a85313b49c4456a7425528d46a4cc58520709c18312228a7c3f051cf19", size = 1027412, upload-time = "2026-05-05T21:13:36.261Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/fe/1f45d3f05b88b394df6974e660ae9479956d99e41f10d9859a1f675f66eb/trossen_arm-1.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b4218b51eece5bfadaa54885bf182dc94325f7a1f8071f225a8e80fe2bbd31f", size = 1137637, upload-time = "2026-05-05T21:13:37.492Z" },
 ]
 
 [[package]]

--- a/examples/trossen_ai/uv.lock
+++ b/examples/trossen_ai/uv.lock
@@ -930,7 +930,7 @@ intelrealsense = [
 [[package]]
 name = "lerobot-robot-trossen"
 version = "0.1.0"
-source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?subdirectory=packages%2Flerobot_robot_trossen&branch=main#d97590da450ea0f0ea0b4f9de4117edcf072e3f3" }
+source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?subdirectory=packages%2Flerobot_robot_trossen&rev=810e60a3d973fa9b23b16db68613c0d4ee03b753#810e60a3d973fa9b23b16db68613c0d4ee03b753" }
 dependencies = [
     { name = "lerobot", extra = ["intelrealsense"] },
     { name = "trossen-arm" },
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "lerobot-teleoperator-trossen"
 version = "0.1.0"
-source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?subdirectory=packages%2Flerobot_teleoperator_trossen&branch=main#d97590da450ea0f0ea0b4f9de4117edcf072e3f3" }
+source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?subdirectory=packages%2Flerobot_teleoperator_trossen&rev=810e60a3d973fa9b23b16db68613c0d4ee03b753#810e60a3d973fa9b23b16db68613c0d4ee03b753" }
 dependencies = [
     { name = "lerobot", extra = ["intelrealsense"] },
     { name = "trossen-arm" },
@@ -948,10 +948,11 @@ dependencies = [
 [[package]]
 name = "lerobot-trossen"
 version = "0.1.0"
-source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?branch=main#d97590da450ea0f0ea0b4f9de4117edcf072e3f3" }
+source = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git?rev=810e60a3d973fa9b23b16db68613c0d4ee03b753#810e60a3d973fa9b23b16db68613c0d4ee03b753" }
 dependencies = [
     { name = "lerobot-robot-trossen" },
     { name = "lerobot-teleoperator-trossen" },
+    { name = "trossen-slate" },
 ]
 
 [[package]]
@@ -2662,12 +2663,23 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "lerobot-trossen", git = "https://github.com/TrossenRobotics/lerobot_trossen.git?branch=main" },
+    { name = "lerobot-trossen", git = "https://github.com/TrossenRobotics/lerobot_trossen.git?rev=810e60a3d973fa9b23b16db68613c0d4ee03b753" },
     { name = "numpy", specifier = ">=1.22.4,<2.0.0" },
     { name = "numpydantic", specifier = ">=1.6.6" },
     { name = "opencv-python", specifier = ">=4.10.0.84" },
     { name = "openpi-client", directory = "../../packages/openpi-client" },
     { name = "scipy", specifier = ">=1.10.1" },
+]
+
+[[package]]
+name = "trossen-slate"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ae/9a81179f7ec2c7027183c2bd087e627a57bb2fd23caec57d71dd6cd7c136/trossen_slate-0.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0673c7dc51e17ab3262462f22aee465c3e9d6230963dee8604fd0e70004e7a34", size = 519978, upload-time = "2025-02-20T00:38:40.924Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/25/30a23574058c4d3607cc275297cb986b0c9fa6c299260fdf0c5002f2ebf6/trossen_slate-0.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7787b56bd247f886beec4a94392a7d99b69b26f59768318793ad46d36e85f753", size = 527143, upload-time = "2025-02-20T00:38:42.164Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/179b2a75c01a27d416fe149c78d4bfd2160af7c98f1353f07eeb349467f8/trossen_slate-0.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8b02c5f2a03fe789f7fb54a74478d5605b4a4a0dfdb855c84ec6f6ffaff5d3c", size = 517733, upload-time = "2025-02-20T00:38:43.352Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/75/e078e860e5561dd11daaaa5a22604f077aa809d8909fc47445037e0e97cc/trossen_slate-0.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:403219999d9dacc5719f2ac133c5c61aa27f4f81e7477f8522105060c9a514bf", size = 525385, upload-time = "2025-02-20T00:38:45.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Installing the `examples/trossen_ai` example currently fails to resolve dependencies on a fresh machine, and after pinning, the client also fails at startup against the pinned API. This PR makes resolution deterministic, aligns the arm driver with the shipped controller firmware, and updates the client to the pinned robot API. Three commits:

1. Pin `lerobot_trossen` to a fixed commit instead of the moving `main` branch.
2. Bump `trossen-arm` to 1.10.0 to match the controller firmware.
3. Update `main.py` to use `robot.action_features` instead of the removed `robot._joint_ft`.

A small README doc fix is also included (correcting a stale config class name in the example snippet).

Base branch: `trossen-ai`. Changes are limited to `examples/trossen_ai/` (`pyproject.toml`, `uv.lock`, `main.py`, `README.md`).

## Problem

A fresh `uv` resolve of the example errors out (reported by a customer):

```
Because only lerobot[intelrealsense]<=0.5.1 is available and lerobot==0.5.1
depends on numpy>=2.0.0,<2.3.0 ... lerobot-robot-trossen==0.1.0 depends on
lerobot[intelrealsense]>=0.5.1 ... And because your project depends on
lerobot-trossen and numpy>=1.22.4,<2.0.0 ... your project's requirements
are unsatisfiable.
```

## Root cause

`examples/trossen_ai/pyproject.toml` pinned its Trossen dependency to a moving git branch (`branch = "main"`). The `lerobot_trossen` `main` branch has since advanced (commit `ca54910`) and raised its floor to `lerobot[intelrealsense]>=0.5.1`, which pulls `numpy>=2.0.0`. As soon as `uv` re-resolves against the branch tip, that collides with this example's own `numpy>=1.22.4,<2.0.0` pin (and the locked `lerobot 0.4.1`), so the resolve becomes unsatisfiable. It surfaces specifically on Python 3.12, which the newer `lerobot_robot_trossen` requires (`>=3.12,<3.13`).

## Fix 1: pin lerobot_trossen to a commit rev

```toml
lerobot_trossen = { git = "https://github.com/TrossenRobotics/lerobot_trossen.git", rev = "810e60a3d973fa9b23b16db68613c0d4ee03b753" }
```

`810e60a` is the latest `lerobot_trossen` commit before the breaking change `ca54910`. It floors at `lerobot[intelrealsense]>=0.4.0` (resolves to `lerobot 0.4.1` / `numpy 1.26.4`, no conflict) while still including the newer WidowX velocity/effort observation work and `trossen-slate`. Pinning a commit keeps `pyproject.toml` and `uv.lock` in agreement so a fresh checkout resolves deterministically.

## Fix 2: bump trossen-arm to 1.10.0

On real hardware, both wxai_v0 arms refused to connect with the freshly resolved `trossen-arm 1.9.0`:

```
Driver version: 'v1.9.0'   |   Controller firmware version: 'v1.10.0'
[CRITICAL] The major and minor versions of the driver and controller firmware must match.
```

The arm controllers ship firmware v1.10.0 and the driver enforces a matching minor version. `trossen-arm 1.10.0` is the latest release, satisfies `trossen_arm>=1.9.0`, only needs `numpy>=1.22.4` (no numpy 2 regression), and ships cp310 through cp313 wheels. The lock had resolved 1.9.0 due to a stale index cache, not a real constraint.

## Fix 3: update client to the pinned robot API

Pinning to `810e60a` is what exposed this: that revision removed the `_joint_ft` property from the bimanual `BiWidowXAIFollower` class in favor of `action_features`. `main.py` still referenced `self.robot._joint_ft`, which raised `AttributeError` on startup once the pinned dependency was installed.

```python
# before
self.action_dim = len(self.robot._joint_ft)
joint_features = list(self.robot._joint_ft.keys())
# after
self.action_dim = len(self.robot.action_features)
joint_features = list(self.robot.action_features.keys())
```

`action_features` exposes the same 14 `left_*` / `right_*` keys (6 joints + gripper per arm) that `robot.send_action` consumes, so behavior is unchanged. `_cameras_ft` still exists at this revision and is left as-is.

## Testing protocol

Prerequisites: `uv` installed and Python 3.12 available. The hardware steps (Parts C and D) require a Trossen AI Stationary Kit (two wxai_v0 arms with controller firmware v1.10.0 and four RealSense D405 cameras), and Part D additionally needs a CUDA GPU to serve the policy.

### Part A: customer install path (no hardware required)

This mirrors exactly what a new customer runs per the example README. It is the path that failed before this change.

1. Clone fresh and check out this branch (a clean clone matters, so resolution is not served from a warm cache):
   ```
   git clone https://github.com/TrossenRobotics/openpi.git
   cd openpi
   git checkout fix/trossen-ai-deps
   ```
2. Run the documented install from `examples/trossen_ai`:
   ```
   cd examples/trossen_ai
   GIT_LFS_SKIP_SMUDGE=1 uv sync
   GIT_LFS_SKIP_SMUDGE=1 uv pip install -e .
   ```
   Expected: resolves and installs with no error. Before this change the same commands fail with `your project's requirements are unsatisfiable` (the numpy 1.x vs 2.x conflict) on Python 3.12.
3. Confirm the resolved versions:
   ```
   uv pip list | grep -E "numpy|lerobot|trossen-arm|torch"
   ```
   Expected: `numpy 1.26.4`, `lerobot 0.4.1`, `trossen-arm 1.10.0`, `torch 2.7.1`, and the `lerobot_trossen` / `lerobot-robot-trossen` packages at commit `810e60a`.

### Part B: imports and robot construction (no hardware required)

4. Confirm the example imports cleanly and can build the robot config object:
   ```
   uv run python -c "from main import TrossenOpenPIBridge; print('import OK')"
   ```
   Expected: prints `import OK` with no `ModuleNotFoundError` or resolution error.

   With hardware connected, also confirm the bridge constructs without the `AttributeError` that Fix 3 addresses (this instantiates the robot and reads `action_features`):
   ```
   uv run main.py --mode test --task_prompt "look down" --max_steps 1
   ```
   Expected: no `AttributeError: ... _joint_ft`; the bridge builds and logs a test-mode step.

### Part C: hardware bring-up (requires the Stationary Kit)

5. With both arms powered and on the network, confirm the driver connects and the firmware versions match:
   - Expected: no `CRITICAL` driver/firmware mismatch; driver `v1.10.0` connects to controller `v1.10.0` on both arms (`192.168.1.5` and `192.168.1.4`).
6. Confirm all four RealSense D405 cameras are detected with the serials in `main.py` and that live frames are captured.
7. Run the bridge in test mode (no motion) to confirm the end-to-end observation path:
   ```
   uv run python main.py --mode test --task_prompt "look down"
   ```
   Expected: observations are collected and logged, no exceptions.

### Part D: real-hardware policy evaluation (requires the Stationary Kit)

End-to-end check that the resolved environment can serve a real trained policy and drive the arms, not just import. Uses the published openpi checkpoint `TrossenRoboticsCommunity/pi05-block-transfer-trossen-ai-openpi` (a JAX/Orbax pi0.5 checkpoint, 14-dim bimanual, `params/` weights plus `assets/trossen/norm_stats.json`). Serving requires a CUDA GPU.

8. Download the checkpoint to a local directory:
   ```
   hf download TrossenRoboticsCommunity/pi05-block-transfer-trossen-ai-openpi \
     --local-dir "$HOME/checkpoints/pi05-block-transfer-trossen-ai-openpi"
   ```
   (On older `huggingface_hub` versions use the equivalent `huggingface-cli download ...`.)
9. From the project root (this uses the root environment, LeRobot V0.1.0), start the policy server:
   ```
   uv run scripts/serve_policy.py policy:checkpoint \
     --policy.config=pi05_trossen_transfer_block \
     --policy.dir="$HOME/checkpoints/pi05-block-transfer-trossen-ai-openpi"
   ```
   Expected: the server loads the params, logs `Loaded norm stats` from `assets/trossen`, and listens on port 8000. The `pi05_trossen_transfer_block` config matches this checkpoint (pi0.5, `asset_id=trossen`, 14-dim bimanual, absolute joint actions).
10. In a second terminal, from `examples/trossen_ai` (this uses the client environment, LeRobot V0.3.2), run the client autonomously:
    ```
    cd examples/trossen_ai
    uv run main.py --mode autonomous --task_prompt "grab and handover the red cube"
    ```
    Expected: the client connects to the server, receives action chunks of shape `(50, 14)`, smoothly interpolates to the first pose, then executes the block-transfer motion on the arms at ~30 Hz with no shape or dimension errors. (Camera and arm IP settings are edited in `main.py` as documented in the example README.)

Evaluation criteria (record per run):
- Connection and shapes: client receives `(50, 14)` chunks at ~30 Hz, no errors.
- Task behavior: run N trials (for example 10) from a consistent start configuration and record success or failure each trial (one arm grasps the red block and transfers or hands it over).
- Expectation, not generalization: this model was trained on a small controlled dataset (53 episodes), so judge it on repeatable success with the red block from the trained start setup. Sensitivity to block color, shape, or environment changes is expected per the example README and is not a failure of this PR.

### Optional: maintainer lock-consistency check

Not part of the customer flow. Use this only to confirm the committed `uv.lock` agrees with `pyproject.toml` (for example in CI):
```
uv lock --locked
```
Expected: passes with no changes. Note this checks the lock against `pyproject.toml` only; it does not detect a moving upstream branch, which is precisely why the dependency is now pinned to an immutable commit rather than `branch = "main"`.

### Pass criteria

- Part A and Part B succeed on Python 3.12 with the exact versions listed above (and Part A fails on the parent commit, confirming this change is what fixes it).
- Part C: both arms connect with matching firmware and all four cameras stream.
- Part D: the policy server loads the checkpoint and the client drives the arms end to end (correct `(50, 14)` action chunks at ~30 Hz), with per-trial block-transfer success recorded.

## Risk and rollback

Scope is limited to the two dependency files in `examples/trossen_ai`; no library or example source code changes. If a regression appears, revert the two commits to restore the previous (branch-based) dependency declaration.
